### PR TITLE
Fix/start lint

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -2,9 +2,6 @@
 
 set -e
 
-# NOTE: The canonical source for this file is in the metabase/metabase repository.
-# Please update it there then copy to the metabase/metabase-deploy repository.
-
 # Translate various Heroku environment variables to Metabase equivalents
 
 if [ "$PORT" ]; then

--- a/bin/start
+++ b/bin/start
@@ -13,7 +13,7 @@ fi
 
 # Heroku Postgres
 if [ "$DATABASE_URL" ]; then
-    if [[ $string == *"?"* ]]; then
+    if [[ "$DATABASE_URL" == *"?"* ]]; then
         # if DATABASE_URL already has a query string don't mess with it
         export MB_DB_CONNECTION_URI="$DATABASE_URL"
     else
@@ -86,9 +86,10 @@ JAVA_OPTS+=" -Djava.awt.headless=true" # don't try to start AWT. Not sure this d
 JAVA_OPTS+=" -Dfile.encoding=UTF-8"    # Use UTF-8
 
 # Set timezone using the JAVA_TIMEZONE variable if present
-if [ "$JAVA_TIMEZONE"]; then
+if [ "$JAVA_TIMEZONE" ]; then
     echo "  -> Timezone setting detected: $JAVA_TIMEZONE"
     JAVA_OPTS+=" -Duser.timezone=$JAVA_TIMEZONE"
 fi
 
+# shellcheck disable=SC2086
 exec java $JAVA_OPTS -jar ./target/uberjar/metabase.jar


### PR DESCRIPTION
while i was checking out [metabase's latest security advisory](https://github.com/metabase/metabase/security/advisories/GHSA-mw6j-f894-4qxv) and trying to update to the latest version, i stumbled upon a bug and lint issue in the start script.

not terribly important. this is probably more important: https://thermondo.atlassian.net/browse/TD-809

but i figured i'd get this merged anyway. this is currently running on https://metabase.thermondo.de .